### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   pylint:
     name: Pylint

--- a/{{cookiecutter.project_name}}/.github/workflows/pylint.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/pylint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   pylint:
     name: Pylint

--- a/{{cookiecutter.project_name}}/entry/settings.py
+++ b/{{cookiecutter.project_name}}/entry/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
 ]
 
 # MIDDLEWARE
+# pylint: disable=C0103
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
     "ovinc_client.core.middlewares.CSRFExemptMiddleware",


### PR DESCRIPTION
Potential fix for [https://github.com/OVINC-CN/DevTemplateDjango/security/code-scanning/6](https://github.com/OVINC-CN/DevTemplateDjango/security/code-scanning/6)

To fix this problem, we need to add a `permissions` key with least privilege at either the workflow root (outside the `jobs:` block, typically right after the workflow `name:` and/or `on:` block) or under the specific job (`pylint`). Given that this workflow does not push or write to the repository, but simply reads code and checks out the contents, the minimum required permission is `contents: read`. Adding `permissions: contents: read` either at the workflow root (to affect all jobs) or under the specific job is sufficient. Since the workflow currently has only one job, either placement is effective, but the root-level placement is recommended for clarity when the workflow might have multiple jobs. Thus, the fix is to add the following explicitly:

```
permissions:
  contents: read
```

Add this after the `name:` and `on:` blocks but before the `jobs:` block in `.github/workflows/pylint.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
